### PR TITLE
VIDIOC_QUERYBUF twice to get the physical address

### DIFF
--- a/src/v4l2src/v4l2_buffer_pool.c
+++ b/src/v4l2src/v4l2_buffer_pool.c
@@ -165,6 +165,15 @@ static GstFlowReturn gst_imx_v4l2_buffer_pool_alloc_buffer(GstBufferPool *bpool,
 			meta->vbuffer.m.offset);
 	g_assert(meta->mem);
 
+	/* Need to query twice to get the physical address */
+	if (ioctl(GST_IMX_FD_OBJECT_GET_FD(pool->fd_obj_v4l), VIDIOC_QUERYBUF, &meta->vbuffer) < 0)
+	{
+		GST_ERROR_OBJECT(pool, "VIDIOC_QUERYBUF for physical address error: %s",
+				g_strerror(errno));
+		gst_buffer_unref(buf);
+		return GST_FLOW_ERROR;
+	}
+
 	phys_mem_meta = GST_IMX_PHYS_MEM_META_ADD(buf);
 	phys_mem_meta->phys_addr = meta->vbuffer.m.offset;
 

--- a/src/v4l2src/v4l2src.c
+++ b/src/v4l2src/v4l2src.c
@@ -275,6 +275,7 @@ static gboolean gst_imx_v4l2src_negotiate(GstBaseSrc *src)
 {
 	GstImxV4l2VideoSrc *v4l2src = GST_IMX_V4L2SRC(src);
 	GstCaps *caps;
+	GstVideoFormat gst_fmt;
 	const char *pixel_format = NULL;
 	struct v4l2_format fmt;
 
@@ -289,7 +290,8 @@ static gboolean gst_imx_v4l2src_negotiate(GstBaseSrc *src)
 		pixel_format = "I420";
 		break;
 	default:
-		pixel_format = (char *)&fmt.fmt.pix.pixelformat;
+		gst_fmt = gst_video_format_from_fourcc(fmt.fmt.pix.pixelformat);
+		pixel_format = gst_video_format_to_string(gst_fmt);
 	}
 
 	/* not much to negotiate;


### PR DESCRIPTION
Copied from a gst1-fsl-plugins-4.0.5, this also makes easy to integrate third-party devices