### PR TITLE
v4l2_captureparm: get the actual frame period if possible

### DIFF
--- a/src/v4l2src/v4l2src.c
+++ b/src/v4l2src/v4l2src.c
@@ -132,6 +132,11 @@ static gint gst_imx_v4l2src_capture_setup(GstImxV4l2VideoSrc *v4l2src)
 		close(fd_v4l);
 		return -1;
 	}
+	/* Get the actual frame period if possible */
+	if (parm.parm.capture.capability & V4L2_CAP_TIMEPERFRAME) {
+		v4l2src->fps_n = parm.parm.capture.timeperframe.denominator;
+		v4l2src->fps_d = parm.parm.capture.timeperframe.numerator;
+	}
 
 	fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 	fmt.fmt.pix.bytesperline = 0;


### PR DESCRIPTION
drivers return the actual frame period, which must be greater or equal to the nominal frame period determined by the current video standard