### PR TITLE
imxv4l2videosrc: added metadata for crop parameters

### DIFF
--- a/src/v4l2src/v4l2_buffer_pool.h
+++ b/src/v4l2src/v4l2_buffer_pool.h
@@ -46,6 +46,10 @@ struct _GstImxV4l2BufferPool
 	guint num_allocated;
 	GstVideoInfo video_info;
 	gboolean add_videometa;
+	guint metaCropX;
+	guint metaCropY;
+	guint metaCropWidth;
+	guint metaCropHeight;
 };
 
 struct _GstImxV4l2BufferPoolClass
@@ -56,7 +60,8 @@ struct _GstImxV4l2BufferPoolClass
 GType gst_imx_v4l2_buffer_pool_get_type(void);
 
 /* Note that this function returns a floating reference. See gst_object_ref_sink() for details. */
-GstBufferPool *gst_imx_v4l2_buffer_pool_new(GstImxFDObject *fd_obj_v4l);
+GstBufferPool *gst_imx_v4l2_buffer_pool_new(GstImxFDObject *fd_obj_v4l, guint metaCropX,
+					    guint metaCropY, guint metaCropWidth, guint metaCropHeight);
 
 struct _GstImxV4l2Meta {
   GstMeta meta;

--- a/src/v4l2src/v4l2src.h
+++ b/src/v4l2src/v4l2src.h
@@ -58,6 +58,10 @@ struct _GstImxV4l2VideoSrc
 	gint input;
 	char *devicename;
 	int queue_size;
+	guint metaCropX;
+	guint metaCropY;
+	guint metaCropWidth;
+	guint metaCropHeight;
 };
 
 struct _GstImxV4l2VideoSrcClass


### PR DESCRIPTION
	Crop metadata can be processed by imxipuvideotransform if
	input-crop property has been set to true.

	parameters:
	crop-meta-x, crop-meta-y, crop-meta-width, crop-meta-height

	example:
	gst-launch-1.0 imxv4l2videosrc crop-meta-x=16 crop-meta-y=48
	crop-meta-width=688 crop-meta-height=480 fps-n=25 ! 'video/x-raw,
	width=720, height=576, format=UYVY, framerate=25/1' !
	imxipuvideotransform input-crop=true ! fakesink

	720x576
	--------------------------------
	|              48              |
	|   ------------------------   |
	|   | 688x480              |   |
	|   |                      |   |
	|16 |                      | 16|
	|   |                      |   |
	|   |                      |   |
	|   ------------------------   |
	|              48              |
	--------------------------------

Signed-off-by: Angelo Aresi <angelo.aresi@bticino.it>