### PR TITLE
fix the blocked issue in mainloop

### DIFF
--- a/src/eglvivsink/egl_platform_wayland.c
+++ b/src/eglvivsink/egl_platform_wayland.c
@@ -896,7 +896,7 @@ GstImxEglVivSinkMainloopRetval gst_imx_egl_viv_sink_egl_platform_mainloop(GstImx
 		{
 			GST_LOG("There is something to read from the display FD - handling events");
 			wl_display_read_events(platform->display);
-			wl_display_dispatch(platform->display);
+			wl_display_dispatch_pending(platform->display);
 		}
 		else
 		{


### PR DESCRIPTION
Sometimes, after setting gstreamer pipeline to NULL state, the mainloop will blocked in wl_display_dispatch, so the mainloop can't receive the GSTIMX_EGLWL_CMD_STOP_MAINLOOP from control pipe. Therefore, the gst_imx_egl_viv_sink_gles2_renderer_stop will never return. 
From the wayland doc, the wl_display_dispatch_pending  will dispatch without block, so we can use it instead.