### PR TITLE
eglvivsink: wayland: Do not commit before buffers are swapped

### DIFF
--- a/src/eglvivsink/egl_platform_wayland.c
+++ b/src/eglvivsink/egl_platform_wayland.c
@@ -377,8 +377,6 @@ static void redraw(GstImxEglVivSinkEGLPlatform *platform)
 	wl_surface_set_opaque_region(platform->surface, region);
 	wl_region_destroy(region);
 
-	/* Finally, do the actual commit to the server */
-	wl_surface_commit(platform->main_surface);
 	eglSwapBuffers(platform->egl_display, platform->egl_surface);
 }
 


### PR DESCRIPTION
eglSwapBuffers will call wl_surface_commit. The current additional
commit causes the compositor to flip buffers with the damage.
Then when eglSwapBuffers calls commit the compositor gets a commit
with empty damage.

Signed-off-by: Richard Röjfors <richard@puffinpack.se>