### PR TITLE
me-search-range property exposed

### DIFF
--- a/src/vpu/encoder_base.h
+++ b/src/vpu/encoder_base.h
@@ -93,6 +93,7 @@ struct _GstImxVpuEncoderBase
 	guint bitrate;
 	gint slice_size;
 	guint intra_refresh;
+	guint me_search_range;
 
 	/* These are used during the actual encoding. The output buffer
 	 * is allocated and mapped to receive the encoded data. */


### PR DESCRIPTION
I have added code which exposes a **me-search-range** property for all imxvpuenc_* encoders. A motion estimation search window can be specified in imxvpuapi imxvpuapi.h but only the default value (0) was used in gstreamer-imx up to now. There are 4 choices:
```
typedef enum
{
  IMX_VPU_ENC_ME_SEARCH_RANGE_256x128 = 0,
  IMX_VPU_ENC_ME_SEARCH_RANGE_128x64,
  IMX_VPU_ENC_ME_SEARCH_RANGE_64x32,
  IMX_VPU_ENC_ME_SEARCH_RANGE_32x32
}
ImxVpuEncMESearchRanges;
```

A smaller  search range reduces the memory read bandwidth needed for encoding. This is crucial in bandwidth limited applications. Especially if the video frame size is smaller, the default (256x128 pixel) seems to be overkill.
Test pipeline (VPU read bandwith reduced by about 13%, measured with mmdc):
```
gst-launch-1.0 imxv4l2videosrc device=/dev/video1 input=0 fps-n=25 \
! imxipuvideotransform deinterlace=1 \
! video/x-raw, format=NV12 \
! imxvpuenc_h264 idr-interval=25 bitrate=8000 me-search-range=3 \
! filesink location=1.h264
```