### PR TITLE
v4l2src: remove format restriction in get_caps function

### DIFF
--- a/src/v4l2src/v4l2_buffer_pool.c
+++ b/src/v4l2src/v4l2_buffer_pool.c
@@ -164,7 +164,7 @@ static GstFlowReturn gst_imx_v4l2_buffer_pool_alloc_buffer(GstBufferPool *bpool,
 	meta->mem = mmap(NULL, meta->vbuffer.length,
 			PROT_READ | PROT_WRITE, MAP_SHARED, GST_IMX_FD_OBJECT_GET_FD(pool->fd_obj_v4l),
 			meta->vbuffer.m.offset);
-	g_assert(meta->mem);
+	g_assert(meta->mem != MAP_FAILED);
 
 	/* Need to query twice to get the physical address */
 	if (ioctl(GST_IMX_FD_OBJECT_GET_FD(pool->fd_obj_v4l), VIDIOC_QUERYBUF, &meta->vbuffer) < 0)

--- a/src/v4l2src/v4l2src.c
+++ b/src/v4l2src/v4l2src.c
@@ -447,13 +447,11 @@ static GstCaps *gst_imx_v4l2src_get_caps(GstBaseSrc *src, GstCaps *filter)
 {
 	GstImxV4l2VideoSrc *v4l2src = GST_IMX_V4L2SRC(src);
 	GstCaps *caps;
-	const gchar *pixel_format = "I420";
 	const gchar *interlace_mode = "progressive";
 
 	GST_INFO_OBJECT(v4l2src, "get caps filter %" GST_PTR_FORMAT, (gpointer)filter);
 
 	caps = gst_caps_new_simple("video/x-raw",
-			"format", G_TYPE_STRING, pixel_format,
 			"width", GST_TYPE_INT_RANGE, 16, G_MAXINT,
 			"height", GST_TYPE_INT_RANGE, 16, G_MAXINT,
 			"interlace-mode", G_TYPE_STRING, interlace_mode,


### PR DESCRIPTION
Fixing the format to I420 in get_caps doesn't allow the following
pipeline on a YUY2 capture device whereas it should work:
 $ gst-launch-1.0 imxv4l2videosrc device=/dev/video1 ! video/x-raw, \
   format=YUY2 ! fakesink

Removing the hardcoded pixel_format leaves it to the negotiate function
to later return the proper format capability, making the plugin more
flexible and now returning a proper error message if the format
requested cannot be negotiated:
streaming task paused, reason not-negotiated (-4)

Another solution would be to limit the format to YUY2 and I420 but it
requires to get a GstStructure from the caps after creation and use
gst_structure_set_value() which isn't as easy as removing the format
field.

Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>