### PR TITLE
phys_mem_meta: properly check for region copy

### DIFF
--- a/src/common/phys_mem_meta.c
+++ b/src/common/phys_mem_meta.c
@@ -62,7 +62,7 @@ static gboolean gst_imx_phys_mem_meta_transform(GstBuffer *dest, GstMeta *meta, 
 		GstMetaTransformCopy *copy = data;
 		gboolean do_copy = FALSE;
 
-		if (!(copy->region)) // TODO: is this check correct?
+		if (copy->region)
 		{
 			GST_LOG("not copying metadata: only a region is being copied (not the entire block)");
 		}


### PR DESCRIPTION
There is a TODO in gst_imx_phys_mem_meta_transform about region copy, and as it stands now it is unfortunately not correct (leading to losing the meta_data upon whole buffer copy).
This can be checked by comparing with other examples such as in gstvideometa.c or gstaudiometa.c etc; typically nothing should happen if (region->copy) (as mentioned in the debug log statement) and lots if not a region copy. 