### PR TITLE
gstreamer-imx: add efficient GRAY8/h264 conversion

### DIFF
--- a/src/v4l2src/v4l2src.c
+++ b/src/v4l2src/v4l2src.c
@@ -529,12 +529,14 @@ static GstCaps *gst_imx_v4l2src_caps_for_current_setup(GstImxV4l2VideoSrc *v4l2s
 #endif
 			gst_fmt = GST_VIDEO_FORMAT_NV16;
 			break;
+#ifdef GST_VIDEO_FORMAT_NV61
 		case V4L2_PIX_FMT_NV61:
 #ifdef V4L2_PIX_FMT_NV61M
 		case V4L2_PIX_FMT_NV61M:
 #endif
 			gst_fmt = GST_VIDEO_FORMAT_NV61;
 			break;
+#endif
 		case V4L2_PIX_FMT_NV24:
 			gst_fmt = GST_VIDEO_FORMAT_NV24;
 			break;

--- a/src/vpu/encoder_base.c
+++ b/src/vpu/encoder_base.c
@@ -316,6 +316,14 @@ static gboolean gst_imx_vpu_encoder_base_start(GstVideoEncoder *encoder)
 static gboolean gst_imx_vpu_encoder_base_stop(GstVideoEncoder *encoder)
 {
 	GstImxVpuEncoderBase *vpu_encoder_base = GST_IMX_VPU_ENCODER_BASE(encoder);
+	GstImxVpuEncoderBaseClass *klass;
+
+	klass = GST_IMX_VPU_ENCODER_BASE_CLASS(G_OBJECT_GET_CLASS(vpu_encoder_base));
+	/* Let the derived class terminate cleanly */
+	if ((klass->close != NULL) && !klass->close(vpu_encoder_base))
+	{
+		GST_ERROR_OBJECT(vpu_encoder_base, "derived class could not terminate cleanly");
+	}
 
 	gst_imx_vpu_encoder_base_close(vpu_encoder_base);
 

--- a/src/vpu/encoder_base.h
+++ b/src/vpu/encoder_base.h
@@ -130,6 +130,9 @@ struct _GstImxVpuEncoderBase
  *                         *output_buffer must point to this new buffer, and the previous
  *                         *output_buffer must be unref'd.
  *                         Returns TRUE if the call succeeded, and FALSE otherwise.
+ * @close:		   Optional.
+ *                         Free all the private allocations done by the subclass
+ *                         Returns TRUE if the call succeeded, and FALSE otherwise.
  */
 struct _GstImxVpuEncoderBaseClass
 {
@@ -141,6 +144,7 @@ struct _GstImxVpuEncoderBaseClass
 	GstCaps* (*get_output_caps)(GstImxVpuEncoderBase *vpu_encoder_base);
 	gboolean (*set_frame_enc_params)(GstImxVpuEncoderBase *vpu_encoder_base, ImxVpuEncParams *enc_params);
 	gboolean (*process_output_buffer)(GstImxVpuEncoderBase *vpu_encoder_base, GstVideoCodecFrame *frame, GstBuffer **output_buffer);
+	gboolean (*close)(GstImxVpuEncoderBase *vpu_encoder_base);
 };
 
 

--- a/src/vpu/encoder_h264.h
+++ b/src/vpu/encoder_h264.h
@@ -46,6 +46,8 @@ struct _GstImxVpuEncoderH264
 	guint idr_interval;
 	gboolean produce_access_units;
 	guint frame_count;
+	ImxVpuDMABuffer *cbcr_buffer;
+	unsigned long cbcr_physaddr;
 };
 
 


### PR DESCRIPTION
This patch series adds efficient GRAY8/h264 conversion to gstreamer-imx,
by using a constant memory zone populated with the value '128' for the
Cb and Cr planes that are requested by h264, but not provided by GRAY8.
Because of the API of libimxvpuapi, I had to set cb_offset and cr_offset
to the difference between the physical address of the new zone and
the physical address of the Y plane, which is a hack I admit, but
this works perfectly.

In order to free cleanly this zone, I needed to add a 'close' vfunc
to encoder_base.

There is also a unrelated new check to allow compilation when
GST_VIDEO_FORMAT_NV61 is not defined.