### PR TITLE
vpu/encoder_base: add zerocopy GRAY8 to h264/h263/mpeg4 encoding

### DIFF
--- a/src/vpu/encoder_base.c
+++ b/src/vpu/encoder_base.c
@@ -317,6 +317,13 @@ static gboolean gst_imx_vpu_encoder_base_stop(GstVideoEncoder *encoder)
 {
 	GstImxVpuEncoderBase *vpu_encoder_base = GST_IMX_VPU_ENCODER_BASE(encoder);
 
+	if (vpu_encoder_base->cbcr_physaddr)
+	{
+		imx_vpu_dma_buffer_deallocate(vpu_encoder_base->cbcr_plane);
+		vpu_encoder_base->cbcr_plane = 0;
+		vpu_encoder_base->cbcr_physaddr = 0;
+	}
+
 	gst_imx_vpu_encoder_base_close(vpu_encoder_base);
 
 	if (vpu_encoder_base->bitstream_buffer != NULL)
@@ -415,6 +422,20 @@ static gboolean gst_imx_vpu_encoder_base_set_format(GstVideoEncoder *encoder, Gs
 	{
 		GST_ERROR_OBJECT(vpu_encoder_base, "derived class could not set open params");
 		return FALSE;
+	}
+
+	if (vpu_encoder_base->need_dummy_cbcr_plane)
+	{
+		if (vpu_encoder_base->cbcr_plane == 0)
+		{
+			unsigned int cbcr_plane_size = vpu_encoder_base->open_params.frame_width * vpu_encoder_base->open_params.frame_height / 4;
+
+			vpu_encoder_base->cbcr_plane = imx_vpu_dma_buffer_allocate(imx_vpu_enc_get_default_allocator(), cbcr_plane_size, 1, 0);
+			vpu_encoder_base->cbcr_physaddr = imx_vpu_dma_buffer_get_physical_address(vpu_encoder_base->cbcr_plane);
+			void *mapped_virtual_address = imx_vpu_dma_buffer_map(vpu_encoder_base->cbcr_plane, IMX_VPU_MAPPING_FLAG_WRITE);
+			memset(mapped_virtual_address, 128, cbcr_plane_size);
+			imx_vpu_dma_buffer_unmap(vpu_encoder_base->cbcr_plane);
+		}
 	}
 
 
@@ -637,6 +658,15 @@ static GstFlowReturn gst_imx_vpu_encoder_base_handle_frame(GstVideoEncoder *enco
 		vpu_encoder_base->input_dmabuffer.fd = -1;
 		vpu_encoder_base->input_dmabuffer.physical_address = phys_mem_meta->phys_addr;
 		vpu_encoder_base->input_dmabuffer.size = gst_buffer_get_size(input_buffer);
+
+		/* If asked by the subclass, provide constant cb- and cr-planes */
+		if (vpu_encoder_base->cbcr_physaddr)
+		{
+			unsigned long y_physaddr = imx_vpu_dma_buffer_get_physical_address(vpu_encoder_base->input_frame.framebuffer->dma_buffer);
+			size_t cbcr_offset = vpu_encoder_base->cbcr_physaddr - y_physaddr;
+			vpu_encoder_base->input_framebuffer.cb_offset = cbcr_offset;
+			vpu_encoder_base->input_framebuffer.cr_offset = cbcr_offset;
+		}
 	}
 
 

--- a/src/vpu/encoder_base.h
+++ b/src/vpu/encoder_base.h
@@ -99,6 +99,11 @@ struct _GstImxVpuEncoderBase
 	 * is allocated and mapped to receive the encoded data. */
 	GstBuffer *output_buffer;
 	GstMapInfo output_buffer_map_info;
+
+	/* These allow zerocopy GRAY8->I420 "conversion" */
+	gboolean need_dummy_cbcr_plane;
+	ImxVpuDMABuffer *cbcr_plane;
+	unsigned long cbcr_physaddr;
 };
 
 

--- a/src/vpu/encoder_h263.c
+++ b/src/vpu/encoder_h263.c
@@ -41,7 +41,7 @@ static GstStaticPadTemplate static_sink_template = GST_STATIC_PAD_TEMPLATE(
 	GST_PAD_ALWAYS,
 	GST_STATIC_CAPS(
 		"video/x-raw,"
-		"format = (string) { I420, NV12 }, "
+		"format = (string) { I420, NV12, GRAY8 }, "
 		"width = (int) [ 48, 1920, 8 ], "
 		"height = (int) [ 32, 1080, 8 ], "
 		"framerate = (fraction) [ 0, MAX ]"
@@ -67,6 +67,7 @@ G_DEFINE_TYPE(GstImxVpuEncoderH263, gst_imx_vpu_encoder_h263, GST_TYPE_IMX_VPU_E
 static void gst_imx_vpu_encoder_h263_set_property(GObject *object, guint prop_id, GValue const *value, GParamSpec *pspec);
 static void gst_imx_vpu_encoder_h263_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
 
+static gboolean gst_imx_vpu_encoder_h263_set_open_params(GstImxVpuEncoderBase *vpu_encoder_base, GstVideoCodecState *input_state, ImxVpuEncOpenParams *open_params);
 static GstCaps* gst_imx_vpu_encoder_h263_get_output_caps(GstImxVpuEncoderBase *vpu_encoder_base);
 static gboolean gst_imx_vpu_encoder_h263_set_frame_enc_params(GstImxVpuEncoderBase *vpu_encoder_base, ImxVpuEncParams *enc_params);
 
@@ -90,6 +91,7 @@ static void gst_imx_vpu_encoder_h263_class_init(GstImxVpuEncoderH263Class *klass
 
 	encoder_base_class->codec_format = IMX_VPU_CODEC_FORMAT_H263;
 
+	encoder_base_class->set_open_params       = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_h263_set_open_params);
 	encoder_base_class->get_output_caps       = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_h263_get_output_caps);
 	encoder_base_class->set_frame_enc_params  = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_h263_set_frame_enc_params);
 
@@ -154,6 +156,17 @@ static void gst_imx_vpu_encoder_h263_get_property(GObject *object, guint prop_id
 			G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 			break;
 	}
+}
+
+
+static gboolean gst_imx_vpu_encoder_h263_set_open_params(GstImxVpuEncoderBase *vpu_encoder_base, GstVideoCodecState *input_state, G_GNUC_UNUSED ImxVpuEncOpenParams *open_params)
+{
+	GstVideoFormat fmt = GST_VIDEO_INFO_FORMAT(&(input_state->info));
+
+	if (fmt == GST_VIDEO_FORMAT_GRAY8)
+		vpu_encoder_base->need_dummy_cbcr_plane = 1;
+
+	return TRUE;
 }
 
 

--- a/src/vpu/encoder_h264.c
+++ b/src/vpu/encoder_h264.c
@@ -49,7 +49,7 @@ static GstStaticPadTemplate static_sink_template = GST_STATIC_PAD_TEMPLATE(
 	GST_PAD_ALWAYS,
 	GST_STATIC_CAPS(
 		"video/x-raw,"
-		"format = (string) { I420, NV12 }, "
+		"format = (string) { I420, NV12, GRAY8 }, "
 		"width = (int) [ 48, 1920, 8 ], "
 		"height = (int) [ 32, 1080, 8 ], "
 		"framerate = (fraction) [ 0, MAX ]"
@@ -191,6 +191,10 @@ gboolean gst_imx_vpu_encoder_h264_set_open_params(GstImxVpuEncoderBase *vpu_enco
 {
 	GstCaps *template_caps, *allowed_caps;
 	GstImxVpuEncoderH264 *vpu_encoder_h264 = GST_IMX_VPU_ENCODER_H264(vpu_encoder_base);
+	GstVideoFormat fmt = GST_VIDEO_INFO_FORMAT(&(input_state->info));
+
+	if (fmt == GST_VIDEO_FORMAT_GRAY8)
+		vpu_encoder_base->need_dummy_cbcr_plane = 1;
 
 	/* Default h.264 open params are already set by the imx_vpu_enc_set_default_open_params()
 	 * call in the base class */

--- a/src/vpu/encoder_mpeg4.c
+++ b/src/vpu/encoder_mpeg4.c
@@ -41,7 +41,7 @@ static GstStaticPadTemplate static_sink_template = GST_STATIC_PAD_TEMPLATE(
 	GST_PAD_ALWAYS,
 	GST_STATIC_CAPS(
 		"video/x-raw,"
-		"format = (string) { I420, NV12 }, "
+		"format = (string) { I420, NV12, GRAY8 }, "
 		"width = (int) [ 48, 1920, 8 ], "
 		"height = (int) [ 32, 1080, 8 ], "
 		"framerate = (fraction) [ 0, MAX ]"
@@ -68,6 +68,7 @@ G_DEFINE_TYPE(GstImxVpuEncoderMPEG4, gst_imx_vpu_encoder_mpeg4, GST_TYPE_IMX_VPU
 static void gst_imx_vpu_encoder_mpeg4_set_property(GObject *object, guint prop_id, GValue const *value, GParamSpec *pspec);
 static void gst_imx_vpu_encoder_mpeg4_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
 
+static gboolean gst_imx_vpu_encoder_mpeg4_set_open_params(GstImxVpuEncoderBase *vpu_encoder_base, GstVideoCodecState *input_state, ImxVpuEncOpenParams *open_params);
 static GstCaps* gst_imx_vpu_encoder_mpeg4_get_output_caps(GstImxVpuEncoderBase *vpu_encoder_base);
 static gboolean gst_imx_vpu_encoder_mpeg4_set_frame_enc_params(GstImxVpuEncoderBase *vpu_encoder_base, ImxVpuEncParams *enc_params);
 
@@ -91,6 +92,7 @@ static void gst_imx_vpu_encoder_mpeg4_class_init(GstImxVpuEncoderMPEG4Class *kla
 
 	encoder_base_class->codec_format = IMX_VPU_CODEC_FORMAT_MPEG4;
 
+	encoder_base_class->set_open_params       = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_mpeg4_set_open_params);
 	encoder_base_class->get_output_caps       = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_mpeg4_get_output_caps);
 	encoder_base_class->set_frame_enc_params  = GST_DEBUG_FUNCPTR(gst_imx_vpu_encoder_mpeg4_set_frame_enc_params);
 
@@ -155,6 +157,17 @@ static void gst_imx_vpu_encoder_mpeg4_get_property(GObject *object, guint prop_i
 			G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
 			break;
 	}
+}
+
+
+gboolean gst_imx_vpu_encoder_mpeg4_set_open_params(GstImxVpuEncoderBase *vpu_encoder_base, GstVideoCodecState *input_state, G_GNUC_UNUSED ImxVpuEncOpenParams *open_params)
+{
+	GstVideoFormat fmt = GST_VIDEO_INFO_FORMAT(&(input_state->info));
+
+	if (fmt == GST_VIDEO_FORMAT_GRAY8)
+		vpu_encoder_base->need_dummy_cbcr_plane = 1;
+
+	return TRUE;
 }
 
 


### PR DESCRIPTION
I know you look at pushing this functionality to libimxvpuapi, so feel free to discard this patch.  But as I have it ready, here it is.

This patch adds zerocopy GRAY8 to h264/h263/mpeg4 conversion by using
a constant memory zone populated with the value '128' for the Cb and Cr
planes that are requested by the h264/h263 and mpeg4 encoders, but
not provided by GRAY8.

As it is needed by the h264, h263 and mpeg4 encoders, and to avoid
code duplication, this has been added to encode_base.c and is
activated by each encoder when needed.

Because of the API of libimxvpuapi, I had to set cb_offset and cr_offset
to the difference between the physical address of the new zone and
the physical address of the Y plane, which is a hack I admit, but
this works perfectly.

Signed-off-by: Philippe De Muyter phdm@macqel.be
