### PR TITLE
Make gstimxcommon library public

### DIFF
--- a/src/common/gstimxcommon.pc.in
+++ b/src/common/gstimxcommon.pc.in
@@ -1,0 +1,10 @@
+prefix=/usr
+exec_prefix=${prefix}
+includedir=${prefix}/include
+libdir=${exec_prefix}/lib
+
+Name: gstimxcommon
+Description: GStreamer IMX memory allocators
+Version: @VERSION@
+Cflags: -I${includedir}/gstreamer-1.0/gst/allocators/imx @CFLAGS@
+Libs: -L${libdir} @LIBS@

--- a/src/common/wscript
+++ b/src/common/wscript
@@ -17,3 +17,15 @@ def build(bld):
 	)
 	if bld.env['BUILD_FOR_ANDROID']:
 		obj.install_path = os.path.join(bld.env['PREFIX'], 'lib')
+
+	bld(
+		source = 'gstimxcommon.pc.in',
+		target = 'gstimxcommon.pc',
+		VERSION = bld.env['GSTIMX_VERSION'],
+        LIBS = '-lgstimxcommon',
+		CFLAGS = '-Wall'
+	)
+
+	bld.install_files('${PREFIX}/include/gstreamer-1.0/gst/allocators/imx', 'phys_mem_allocator.h')
+	bld.install_files('${PREFIX}/include/gstreamer-1.0/gst/allocators/imx', 'phys_mem_addr.h')
+	bld.install_files('${PREFIX}/include/gstreamer-1.0/gst/allocators/imx', 'phys_mem_meta.h')


### PR DESCRIPTION
Necessary when implementing external sinks to retrieve the mapped
physical memory address from gstreamer buffers.