### PR TITLE
compositor: Only copy compositor input buffers to DMA memory once

### DIFF
--- a/src/blitter/blitter.h
+++ b/src/blitter/blitter.h
@@ -238,6 +238,7 @@ gboolean gst_imx_blitter_set_num_output_pages(GstImxBlitter *blitter, guint num_
  * if @set_input_frame succeeded, FALSE otherwise.
  */
 gboolean gst_imx_blitter_set_input_frame(GstImxBlitter *blitter, GstBuffer *frame);
+gboolean gst_imx_blitter_set_input_frame_and_cache(GstImxBlitter *blitter, GstBuffer **frame);
 /* Sets the output frame.
  *
  * Internally, this calls @set_output_frame, and returns its return value.

--- a/src/blitter/compositor.c
+++ b/src/blitter/compositor.c
@@ -18,7 +18,7 @@ GstAllocator* gst_imx_blitter_compositor_get_phys_mem_allocator(GstImxVideoCompo
 gboolean gst_imx_blitter_compositor_set_output_frame(GstImxVideoCompositor *compositor, GstBuffer *output_frame);
 gboolean gst_imx_blitter_compositor_set_output_video_info(GstImxVideoCompositor *compositor, GstVideoInfo const *info);
 gboolean gst_imx_blitter_compositor_fill_region(GstImxVideoCompositor *compositor, GstImxRegion const *region, guint32 color);
-gboolean gst_imx_blitter_compositor_draw_frame(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer *input_frame, guint8 alpha);
+gboolean gst_imx_blitter_compositor_draw_frame(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer **input_frame, guint8 alpha);
 
 
 
@@ -168,7 +168,7 @@ gboolean gst_imx_blitter_compositor_fill_region(GstImxVideoCompositor *composito
 }
 
 
-gboolean gst_imx_blitter_compositor_draw_frame(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer *input_frame, guint8 alpha)
+gboolean gst_imx_blitter_compositor_draw_frame(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer **input_frame, guint8 alpha)
 {
 	gboolean ret = TRUE;
 	GstImxBlitterCompositor *blitter_compositor = GST_IMX_BLITTER_COMPOSITOR(compositor);
@@ -176,7 +176,7 @@ gboolean gst_imx_blitter_compositor_draw_frame(GstImxVideoCompositor *compositor
 
 	ret = ret && gst_imx_blitter_set_input_video_info(blitter_compositor->blitter, input_info);
 	ret = ret && gst_imx_blitter_set_input_region(blitter_compositor->blitter, input_region);
-	ret = ret && gst_imx_blitter_set_input_frame(blitter_compositor->blitter, input_frame);
+	ret = ret && gst_imx_blitter_set_input_frame_and_cache(blitter_compositor->blitter, input_frame);
 	ret = ret && gst_imx_blitter_set_output_canvas(blitter_compositor->blitter, output_canvas);
 
 	ret = ret && gst_imx_blitter_blit(blitter_compositor->blitter, alpha);

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -866,7 +866,7 @@ static GstFlowReturn gst_imx_video_compositor_aggregate_frames(GstImxBPVideoAggr
 					&(videoaggregator_pad->info),
 					&(compositor_pad->source_subset),
 					&(compositor_pad->canvas),
-					videoaggregator_pad->buffer,
+					&videoaggregator_pad->buffer,
 					(guint8)(compositor_pad->alpha * 255.0)
 				))
 				{

--- a/src/compositor/compositor.h
+++ b/src/compositor/compositor.h
@@ -97,7 +97,7 @@ struct _GstImxVideoCompositorClass
 	gboolean (*set_output_frame)(GstImxVideoCompositor *compositor, GstBuffer *output_frame);
 	gboolean (*set_output_video_info)(GstImxVideoCompositor *compositor, GstVideoInfo const *info);
 	gboolean (*fill_region)(GstImxVideoCompositor *compositor, GstImxRegion const *region, guint32 color);
-	gboolean (*draw_frame)(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer *input_frame, guint8 alpha);
+	gboolean (*draw_frame)(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer **input_frame, guint8 alpha);
 };
 
 


### PR DESCRIPTION
If a single input frame is used for multiple output frames, we would
otherwise copy multiple times which can easily go to the limit of the
memory bandwidth.