### PR TITLE
Use new GstPhysMemory from gst-plugins-bad

### DIFF
--- a/src/common/phys_mem_allocator.c
+++ b/src/common/phys_mem_allocator.c
@@ -15,10 +15,14 @@
  * License along with this library; if not, write to the Free
  * Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
-
+#include <config.h>
 
 #include <string.h>
 #include "phys_mem_allocator.h"
+
+#ifdef WITH_GSTBADALLOCATORS
+#include <gst/allocators/gstphysmemory.h>
+#endif
 
 
 GST_DEBUG_CATEGORY_STATIC(imx_phys_mem_allocator_debug);
@@ -34,9 +38,27 @@ static GstMemory* gst_imx_phys_mem_allocator_copy(GstMemory *mem, gssize offset,
 static GstMemory* gst_imx_phys_mem_allocator_share(GstMemory *mem, gssize offset, gssize size);
 static gboolean gst_imx_phys_mem_allocator_is_span(GstMemory *mem1, GstMemory *mem2, gsize *offset);
 
+#ifdef WITH_GSTBADALLOCATORS
 
+static guintptr gst_imx_phys_mem_allocator_get_phys_addr(GstPhysMemoryAllocator *allocator, GstMemory *mem)
+{
+  if (!gst_imx_is_phys_memory(mem))
+    return 0;
+
+  return ((GstImxPhysMemory *)mem)->phys_addr;
+}
+
+static void gst_imx_phys_mem_allocator_iface_init(gpointer g_iface)
+{
+  GstPhysMemoryAllocatorInterface *iface = g_iface;
+
+  iface->get_phys_addr = gst_imx_phys_mem_allocator_get_phys_addr;
+}
+
+G_DEFINE_ABSTRACT_TYPE_WITH_CODE(GstImxPhysMemAllocator, gst_imx_phys_mem_allocator, GST_TYPE_ALLOCATOR, G_IMPLEMENT_INTERFACE(GST_TYPE_PHYS_MEMORY_ALLOCATOR, gst_imx_phys_mem_allocator_iface_init))
+#else
 G_DEFINE_ABSTRACT_TYPE(GstImxPhysMemAllocator, gst_imx_phys_mem_allocator, GST_TYPE_ALLOCATOR)
-
+#endif
 
 void gst_imx_phys_mem_allocator_class_init(GstImxPhysMemAllocatorClass *klass)
 {

--- a/src/common/phys_mem_allocator.h
+++ b/src/common/phys_mem_allocator.h
@@ -20,14 +20,14 @@
 #ifndef GST_IMX_COMMON_PHYS_MEM_ALLOCATOR_H
 #define GST_IMX_COMMON_PHYS_MEM_ALLOCATOR_H
 
+#include <config.h>
+
 #include <gst/gst.h>
 #include <gst/gstallocator.h>
 
 #include "phys_mem_addr.h"
 
-
 G_BEGIN_DECLS
-
 
 typedef struct _GstImxPhysMemAllocator GstImxPhysMemAllocator;
 typedef struct _GstImxPhysMemAllocatorClass GstImxPhysMemAllocatorClass;

--- a/wscript
+++ b/wscript
@@ -166,6 +166,8 @@ def configure(conf):
 		conf.env['WITH_GSTVIDEO'] = True
 	else:
 		Logs.pprint('RED', 'could not find gstvideo library - not building video plugins')
+	if conf.check_cfg(package = 'gstreamer-bad-allocators-1.0', uselib_store = 'GSTREAMER_BAD_ALLOCATORS', args = '--cflags --libs', mandatory = 0):
+		conf.env['WITH_GSTBADALLOCATORS'] = True
 	if conf.check_cc(lib = 'gstphotography-1.0', uselib_store = 'GSTPHOTOGRAPHY', mandatory = 0):
 		conf.env['WITH_GSTPHOTOGRAPHY'] = True
 
@@ -187,8 +189,11 @@ def configure(conf):
 	conf.define('PACKAGE_BUGREPORT', "https://github.com/Freescale/gstreamer-imx")
 	conf.define('VERSION', gstimx_version)
 
+	if conf.env['WITH_GSTBADALLOCATORS']:
+		conf.define('WITH_GSTBADALLOCATORS', 1)
+
 	conf.env['GSTIMX_VERSION'] = gstimx_version
-	conf.env['COMMON_USELIB'] = ['GSTREAMER', 'GSTREAMER_BASE', 'GSTREAMER_AUDIO', 'GSTREAMER_VIDEO', 'PTHREAD', 'M']
+	conf.env['COMMON_USELIB'] = ['GSTREAMER', 'GSTREAMER_BASE', 'GSTREAMER_AUDIO', 'GSTREAMER_VIDEO', 'GSTREAMER_BAD_ALLOCATORS', 'PTHREAD', 'M']
 
 
 	conf.recurse('src/common')


### PR DESCRIPTION
But only optionally, if not available have a simple copy of the struct
for backwards compatibility.

https://bugzilla.gnome.org/show_bug.cgi?id=779067