### PR TITLE
unref video_frame memory after phys_memory check

### DIFF
--- a/src/g2d/pango/basetextoverlay.c
+++ b/src/g2d/pango/basetextoverlay.c
@@ -2254,11 +2254,17 @@ gst_imx_g2d_base_text_overlay_blend_g2d(GstImxG2DBaseTextOverlay * overlay,
 {
   void *g2d_handle;
   gboolean ret = TRUE;
+  GstMemory *video_mem;
+  gboolean is_phys_mem;
 
   g_assert_nonnull(video_frame);
   g_assert_nonnull(overlay->text_image);
 
-  if (!gst_imx_is_phys_memory(gst_buffer_get_memory(video_frame, 0))) {
+  video_mem = gst_buffer_get_memory(video_frame, 0);
+  is_phys_mem = gst_imx_is_phys_memory(video_mem);
+  gst_memory_unref(video_mem);
+
+  if (!is_phys_mem) {
     GST_ERROR_OBJECT (overlay, "video frame data is not contiguous physical memory");
     return FALSE;
   }


### PR DESCRIPTION
We discovered a missing unref in the imxg2dtextoverlay plugin, this meant that the imxg2dvideotransform output buffer was not being freed when the pipeline was pulled down. Eventually fixed it with this patch. hope it is useful to you. 

Interestingly this leak only seemed to manifest when we constructed our own pipeline. Using a playbin element (patched to use imxg2dtextoverlay) didn't have the leak, intrigued as to whether any maintainers know how this is "cleaning up" without this patch.
 
Mark.