### PR TITLE
Fix integration with GStreamer 1.14

### DIFF
--- a/src/common/phys_mem_allocator.c
+++ b/src/common/phys_mem_allocator.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include "phys_mem_allocator.h"
 
-#ifdef WITH_GSTBADALLOCATORS
+#ifdef WITH_GSTALLOCATORS
 #include <gst/allocators/gstphysmemory.h>
 #endif
 
@@ -38,7 +38,7 @@ static GstMemory* gst_imx_phys_mem_allocator_copy(GstMemory *mem, gssize offset,
 static GstMemory* gst_imx_phys_mem_allocator_share(GstMemory *mem, gssize offset, gssize size);
 static gboolean gst_imx_phys_mem_allocator_is_span(GstMemory *mem1, GstMemory *mem2, gsize *offset);
 
-#ifdef WITH_GSTBADALLOCATORS
+#ifdef WITH_GSTALLOCATORS
 
 static guintptr gst_imx_phys_mem_allocator_get_phys_addr(GstPhysMemoryAllocator *allocator, GstMemory *mem)
 {

--- a/wscript
+++ b/wscript
@@ -167,7 +167,9 @@ def configure(conf):
 	else:
 		Logs.pprint('RED', 'could not find gstvideo library - not building video plugins')
 	if conf.check_cfg(package = 'gstreamer-bad-allocators-1.0', uselib_store = 'GSTREAMER_BAD_ALLOCATORS', args = '--cflags --libs', mandatory = 0):
-		conf.env['WITH_GSTBADALLOCATORS'] = True
+		conf.env['WITH_GSTALLOCATORS'] = True
+	if conf.check_cfg(package = 'gstreamer-allocators-1.0', uselib_store = 'GSTREAMER_ALLOCATORS', args = '--cflags --libs', mandatory = 0):
+		conf.env['WITH_GSTALLOCATORS'] = True
 	if conf.check_cc(lib = 'gstphotography-1.0', uselib_store = 'GSTPHOTOGRAPHY', mandatory = 0):
 		conf.env['WITH_GSTPHOTOGRAPHY'] = True
 
@@ -196,11 +198,11 @@ def configure(conf):
 	conf.define('PACKAGE_BUGREPORT', "https://github.com/Freescale/gstreamer-imx")
 	conf.define('VERSION', gstimx_version)
 
-	if conf.env['WITH_GSTBADALLOCATORS']:
-		conf.define('WITH_GSTBADALLOCATORS', 1)
+	if conf.env['WITH_GSTALLOCATORS']:
+		conf.define('WITH_GSTALLOCATORS', 1)
 
 	conf.env['GSTIMX_VERSION'] = gstimx_version
-	conf.env['COMMON_USELIB'] = ['GSTREAMER', 'GSTREAMER_BASE', 'GSTREAMER_AUDIO', 'GSTREAMER_VIDEO', 'GSTREAMER_BAD_ALLOCATORS', 'PTHREAD', 'M']
+	conf.env['COMMON_USELIB'] = ['GSTREAMER', 'GSTREAMER_BASE', 'GSTREAMER_AUDIO', 'GSTREAMER_VIDEO', 'GSTREAMER_ALLOCATORS', 'GSTREAMER_BAD_ALLOCATORS', 'PTHREAD', 'M']
 
 
 	conf.recurse('src/common')


### PR DESCRIPTION
In GStreamer 1.14 the GstPhysMemoryAllocator interface moved from -bad
to -base.

Fixes /issues/228