### PR TITLE
audio: Only allocate reordered_channel_positions if needed

### DIFF
--- a/src/audio/uniaudio_decoder.c
+++ b/src/audio/uniaudio_decoder.c
@@ -623,7 +623,6 @@ static void gst_imx_audio_uniaudio_dec_fill_channel_positions(GstImxAudioUniaudi
 	gsize num_chanpos_bytes = num_channels * sizeof(GstAudioChannelPosition);
 
 	imx_audio_uniaudio_dec->original_channel_positions = g_malloc0(num_chanpos_bytes);
-	imx_audio_uniaudio_dec->reordered_channel_positions = g_malloc0(num_chanpos_bytes);
 
 	if (num_channels == 1)
 	{
@@ -661,6 +660,7 @@ static void gst_imx_audio_uniaudio_dec_fill_channel_positions(GstImxAudioUniaudi
 	else
 	{
 		GST_DEBUG_OBJECT(imx_audio_uniaudio_dec, "channel positions are not in valid order -> need to reorder channels");
+		imx_audio_uniaudio_dec->reordered_channel_positions = g_malloc0(num_chanpos_bytes);
 		memcpy(imx_audio_uniaudio_dec->reordered_channel_positions, imx_audio_uniaudio_dec->original_channel_positions, num_chanpos_bytes);
 		gst_audio_channel_positions_to_valid_order(imx_audio_uniaudio_dec->reordered_channel_positions, num_channels);
 	}


### PR DESCRIPTION
If we didn't need to reorder the audio channels, we leak the
unnecessary allocation.

Signed-off-by: Doug Nazar <nazard@nazar.ca>