### PR TITLE
ext/audio: Fix build issue when uniaudiodec is disabled

### DIFF
--- a/ext/audio/meson.build
+++ b/ext/audio/meson.build
@@ -5,6 +5,7 @@ endif
 
 # Check for the libfslaudiocodec library to build the uniaudiodec element
 libfslaudiocodec_dep = dependency('libfslaudiocodec', required : get_option('uniaudiodec'))
+fslcodec_libdirvar = ''
 if libfslaudiocodec_dep.found()
 	fslcodec_libdirvar = libimxdmabuffer_dep.get_pkgconfig_variable('libdir', default : '')
 	if fslcodec_libdirvar != ''


### PR DESCRIPTION
The mp3encoder dependency relies on the fslcodec_libdirvar, which used to be set
only if the libfslaudiocodec library is found. This patch fixes the following
error:

| Dependency libfslaudiocodec skipped: feature uniaudiodec disabled
| Message: Installed fslaudiocodec library not found, or user disabled uniaudiodec element compilation - uniaudio decoder will not be built
|
| ext/audio/meson.build:21:0: ERROR:  Unknown variable "fslcodec_libdirvar".
|