### PR TITLE
Update decoder.c

### DIFF
--- a/src/vpu/decoder.c
+++ b/src/vpu/decoder.c
@@ -1126,7 +1126,10 @@ static void gst_imx_vpu_decoder_close(GstImxVpuDecoder *vpu_decoder)
 static void gst_imx_vpu_decoder_close_and_clear_decoder_context(GstImxVpuDecoder *vpu_decoder)
 {
 	if (vpu_decoder->decoder_context == NULL)
+	{	
+		gst_imx_vpu_decoder_close(vpu_decoder);
 		return;
+	}
 
 	GST_INFO_OBJECT(vpu_decoder, "Clearing decoder context");
 


### PR DESCRIPTION
I have found that frequent format changes causes leaks of the vpu_decoder->decoder structure, and there are only 32.  The reason is that if we come into this function with a NULL context, we skip the code that calls decoder close.  It happens that the context can be NULL but the vpu_decoder->decoder can still be open.