### PR TITLE
Cache temporary DMA bufferpools in blitter compositor

### DIFF
--- a/src/blitter/blitter.c
+++ b/src/blitter/blitter.c
@@ -116,6 +116,15 @@ gboolean gst_imx_blitter_set_input_video_info(GstImxBlitter *blitter, GstVideoIn
 	return TRUE;
 }
 
+gboolean gst_imx_blitter_set_input_dma_bufferpool(GstImxBlitter *blitter, GstBufferPool *dma_bufferpool)
+{
+	if (blitter->dma_bufferpool)
+		gst_object_unref (blitter->dma_bufferpool);
+
+	blitter->dma_bufferpool = dma_bufferpool ? gst_object_ref (dma_bufferpool) : NULL;
+
+	return TRUE;
+}
 
 gboolean gst_imx_blitter_set_output_video_info(GstImxBlitter *blitter, GstVideoInfo const *output_video_info)
 {

--- a/src/blitter/blitter.h
+++ b/src/blitter/blitter.h
@@ -188,6 +188,13 @@ struct _GstImxBlitterClass
 
 GType gst_imx_blitter_get_type(void);
 
+/* Sets the input DMA buffer pool.
+ *
+ * This buffer pool is going to be used for allocating temporary input frames
+ * if needed. The caller must ensure that the pool is activated and configured
+ * for the correct input video info.
+ */
+gboolean gst_imx_blitter_set_input_dma_bufferpool(GstImxBlitter *blitter, GstBufferPool *dma_bufferpool);
 
 /* Sets the input video info.
  *

--- a/src/blitter/compositor.h
+++ b/src/blitter/compositor.h
@@ -24,6 +24,9 @@ struct _GstImxBlitterCompositor
 {
 	GstImxVideoCompositor parent;
 	GstImxBlitter *blitter;
+
+	/* Pad to cached buffer pool hashtable */
+	GHashTable *dma_bufferpools;
 };
 
 

--- a/src/compositor/compositor.c
+++ b/src/compositor/compositor.c
@@ -863,6 +863,7 @@ static GstFlowReturn gst_imx_video_compositor_aggregate_frames(GstImxBPVideoAggr
 
 				if (!klass->draw_frame(
 					compositor,
+					compositor_pad,
 					&(videoaggregator_pad->info),
 					&(compositor_pad->source_subset),
 					&(compositor_pad->canvas),

--- a/src/compositor/compositor.h
+++ b/src/compositor/compositor.h
@@ -97,7 +97,7 @@ struct _GstImxVideoCompositorClass
 	gboolean (*set_output_frame)(GstImxVideoCompositor *compositor, GstBuffer *output_frame);
 	gboolean (*set_output_video_info)(GstImxVideoCompositor *compositor, GstVideoInfo const *info);
 	gboolean (*fill_region)(GstImxVideoCompositor *compositor, GstImxRegion const *region, guint32 color);
-	gboolean (*draw_frame)(GstImxVideoCompositor *compositor, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer **input_frame, guint8 alpha);
+	gboolean (*draw_frame)(GstImxVideoCompositor *compositor, GstImxVideoCompositorPad *pad, GstVideoInfo const *input_info, GstImxRegion const *input_region, GstImxCanvas const *output_canvas, GstBuffer **input_frame, guint8 alpha);
 };
 
 


### PR DESCRIPTION
Otherwise they would be recreated for every single frame if there are
multiple input streams with different caps, which causes considerable
performance problems.

Fixes https://github.com/Freescale/gstreamer-imx/issues/201