### PR TITLE
video_sink: clear on relocate.

### DIFF
--- a/src/blitter/video_sink.h
+++ b/src/blitter/video_sink.h
@@ -77,6 +77,7 @@ struct _GstImxBlitterVideoSink
 	guint old_fb_page;
 	gboolean use_vsync;
 	gboolean clear_at_null;
+	gboolean clear_on_relocate;
 	gboolean input_crop;
 	gboolean last_frame_with_cropdata;
 
@@ -97,6 +98,7 @@ struct _GstImxBlitterVideoSink
 	GstImxRegion input_region;
 	GstImxRegion last_source_region;
 	gboolean canvas_needs_update;
+	gboolean canvas_bounds_changed;
 };
 
 


### PR DESCRIPTION
Added new optional feature, clear the screen when relocating the video window.
Fixes: #186