### PR TITLE
imxvpuenc: Add support for intra-refresh

### DIFF
--- a/ext/vpu/gstimxvpuenc.h
+++ b/ext/vpu/gstimxvpuenc.h
@@ -102,6 +102,7 @@ struct _GstImxVpuEnc
 	guint gop_size;
 	guint bitrate;
 	guint quantization;
+	guint intra_refresh;
 };
 
 
@@ -121,7 +122,7 @@ struct _GstImxVpuEncClass
 };
 
 
-void gst_imx_vpu_enc_common_class_init(GstImxVpuEncClass *klass, ImxVpuApiCompressionFormat compression_format, gboolean with_rate_control, gboolean with_constant_quantization, gboolean with_gop_support);
+void gst_imx_vpu_enc_common_class_init(GstImxVpuEncClass *klass, ImxVpuApiCompressionFormat compression_format, gboolean with_rate_control, gboolean with_constant_quantization, gboolean with_gop_support, gboolean with_intra_refresh);
 void gst_imx_vpu_enc_common_init(GstImxVpuEnc *imx_vpu_enc);
 
 GType gst_imx_vpu_enc_get_type(void);

--- a/ext/vpu/gstimxvpuench263.c
+++ b/ext/vpu/gstimxvpuench263.c
@@ -84,7 +84,7 @@ static void gst_imx_vpu_enc_h263_class_init(GstImxVpuEncH263Class *klass)
 	imx_vpu_enc_class->set_open_params = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_h263_set_open_params);
 	imx_vpu_enc_class->get_output_caps = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_h263_get_output_caps);
 
-	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_H263, TRUE, TRUE, TRUE);
+	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_H263, TRUE, TRUE, TRUE, FALSE);
 
 	g_object_class_install_property(
 		object_class,

--- a/ext/vpu/gstimxvpuench264.c
+++ b/ext/vpu/gstimxvpuench264.c
@@ -56,7 +56,7 @@ static void gst_imx_vpu_enc_h264_class_init(GstImxVpuEncH264Class *klass)
 	imx_vpu_enc_class->set_open_params = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_h264_set_open_params);
 	imx_vpu_enc_class->get_output_caps = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_h264_get_output_caps);
 
-	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_H264, TRUE, TRUE, TRUE);
+	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_H264, TRUE, TRUE, TRUE, TRUE);
 }
 
 

--- a/ext/vpu/gstimxvpuencjpeg.c
+++ b/ext/vpu/gstimxvpuencjpeg.c
@@ -53,7 +53,7 @@ static void gst_imx_vpu_enc_jpeg_class_init(GstImxVpuEncJPEGClass *klass)
 	imx_vpu_enc_class = GST_IMX_VPU_ENC_CLASS(klass);
 	imx_vpu_enc_class->get_output_caps = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_jpeg_get_output_caps);
 
-	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_JPEG, FALSE, TRUE, FALSE);
+	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_JPEG, FALSE, TRUE, FALSE, FALSE);
 }
 
 

--- a/ext/vpu/gstimxvpuencmpeg4.c
+++ b/ext/vpu/gstimxvpuencmpeg4.c
@@ -87,7 +87,7 @@ static void gst_imx_vpu_enc_mpeg4_class_init(GstImxVpuEncMPEG4Class *klass)
 	imx_vpu_enc_class->set_open_params = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_mpeg4_set_open_params);
 	imx_vpu_enc_class->get_output_caps = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_mpeg4_get_output_caps);
 
-	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_MPEG4, TRUE, TRUE, TRUE);
+	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_MPEG4, TRUE, TRUE, TRUE, FALSE);
 
 	g_object_class_install_property(
 		object_class,

--- a/ext/vpu/gstimxvpuencvp8.c
+++ b/ext/vpu/gstimxvpuencvp8.c
@@ -56,7 +56,7 @@ static void gst_imx_vpu_enc_vp8_class_init(GstImxVpuEncVP8Class *klass)
 	imx_vpu_enc_class->set_open_params = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_vp8_set_open_params);
 	imx_vpu_enc_class->get_output_caps = GST_DEBUG_FUNCPTR(gst_imx_vpu_enc_vp8_get_output_caps);
 
-	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_VP8, TRUE, TRUE, TRUE);
+	gst_imx_vpu_enc_common_class_init(imx_vpu_enc_class, IMX_VPU_API_COMPRESSION_FORMAT_VP8, TRUE, TRUE, TRUE, FALSE);
 }
 
 


### PR DESCRIPTION
This is currently only enabled for H264 and could possibly be enabled
later for H265 too once an encoder for it is added.

Fixes https://github.com/Freescale/gstreamer-imx/issues/284