### PR TITLE
Unlock decoder_context on fatal error while decoding.

### DIFF
--- a/ext/vpu/gstimxvpudec.c
+++ b/ext/vpu/gstimxvpudec.c
@@ -914,6 +914,8 @@ static GstFlowReturn gst_imx_vpu_dec_decode_queued_frames(GstImxVpuDec *imx_vpu_
 			{
 				GST_ERROR_OBJECT(imx_vpu_dec, "could not prepare output buffer: %s", gst_flow_get_name(flow_ret));
 				imx_vpu_dec->fatal_error_cannot_decode = TRUE;
+				if (imx_vpu_dec->decoder_context != NULL)
+					GST_IMX_VPU_DEC_CONTEXT_UNLOCK(imx_vpu_dec->decoder_context);
 				goto finish;
 			}
 		}


### PR DESCRIPTION
Ran into this while debugging several files failing to play. Turns out the new setup uses a little bit more memory than v1 and I need to bump my graphics CMA size. Not sure if this should be mentioned in the README.
