### PR TITLE
vpu: decoder: Use default query handler for accept-caps.

### DIFF
--- a/ext/vpu/gstimxvpudec.c
+++ b/ext/vpu/gstimxvpudec.c
@@ -206,6 +206,11 @@ static void gst_imx_vpu_dec_init(GstImxVpuDec *imx_vpu_dec)
 	imx_vpu_dec->output_is_tiled = FALSE;
 
 	imx_vpu_dec->fatal_error_cannot_decode = FALSE;
+
+	GST_PAD_SET_ACCEPT_TEMPLATE(GST_VIDEO_DECODER_SINK_PAD(imx_vpu_dec));
+	gst_video_decoder_set_use_default_pad_acceptcaps(GST_VIDEO_DECODER_CAST(imx_vpu_dec), TRUE);
+
+	gst_video_decoder_set_needs_format(GST_VIDEO_DECODER_CAST(imx_vpu_dec), TRUE);
 }
 
 


### PR DESCRIPTION
Handling *accept-caps* improves pipeline caps negotiation and seems to be required for gap-less playback in Gstreamer 1.24.

`gst_video_decoder_set_needs_format()` just formalizes and ensures `handle_frame()` isn't called before `set_format()`. 
This ensures the `decoder` will be created first.