### PR TITLE
Enable building as a custom submodule of gstreamer

### DIFF
--- a/ext/audio/meson.build
+++ b/ext/audio/meson.build
@@ -39,7 +39,7 @@ if mp3encoder_dep.found()
 endif
 
 if source != []
-	library(
+	gstimxaudio = library(
 		'gstimxaudio',
 		source,
 		install : true,
@@ -48,5 +48,6 @@ if source != []
 		dependencies : [gstreamer_dep, gstreamer_base_dep, gstreamer_audio_dep, libdl_dep, libfslaudiocodec_dep, mp3encoder_dep],
 		link_with : [gstimxcommon]
 	)
+	plugins += [gstimxaudio]
 endif
 

--- a/ext/imx2d/meson.build
+++ b/ext/imx2d/meson.build
@@ -83,7 +83,7 @@ if imx2d_backend_pxp_dep.found()
 endif
 
 if backend_source.length() > 0
-	library(
+	gstimx2d = library(
 		'gstimx2d',
 		source + backend_source,
 		install : true,
@@ -91,4 +91,5 @@ if backend_source.length() > 0
 		include_directories: [configinc, libsinc],
 		dependencies : [gstimxcommon_dep, gstimxvideo_dep, gstreamer_video_dep, imx2d_dep] + backend_deps
 	)
+	plugins += [gstimx2d]
 endif

--- a/ext/vpu/meson.build
+++ b/ext/vpu/meson.build
@@ -27,7 +27,7 @@ source = [
 ]
 
 
-library(
+gstimxvpu = library(
 	'gstimxvpu',
 	source,
 	install : true,
@@ -36,3 +36,4 @@ library(
 	dependencies : [gstimxcommon_dep, gstreamer_video_dep, libimxvpuapi2_dep],
 	link_with : [gstimxcommon]
 )
+plugins += [gstimxvpu]

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ message('Setting up build configuration for gstreamer-imx version ' + meson.proj
 
 cc = meson.get_compiler('c')
 pkg = import('pkgconfig')
+plugins = []
 
 
 # test for miscellaneous system libraries
@@ -95,9 +96,18 @@ endif
 configinc = include_directories('.')
 libsinc = include_directories('gst-libs')
 
+gst_package_name = get_option('package-name')
+if gst_package_name == ''
+  fs = import('fs')
+  if fs.is_dir('.git')
+    gst_package_name = 'GStreamer i.MX Plug-ins git'
+  else
+    gst_package_name = 'GStreamer i.MX Plug-ins source release'
+  endif
+endif
 
 conf_data = configuration_data()
-conf_data.set_quoted('GST_PACKAGE_NAME', get_option('package-name'))
+conf_data.set_quoted('GST_PACKAGE_NAME', gst_package_name)
 conf_data.set_quoted('GST_PACKAGE_ORIGIN', get_option('package-origin'))
 conf_data.set_quoted('PACKAGE', 'gstreamer-imx')
 conf_data.set_quoted('PACKAGE_BUGREPORT', 'https://github.com/Freescale/gstreamer-imx')
@@ -123,3 +133,12 @@ subdir('sys/v4l2video')
 
 
 configure_file(output : 'config.h', configuration : conf_data)
+
+if meson.version().version_compare('>=0.54')
+  gst_plugins = []
+  foreach plugin: plugins
+    dep = declare_dependency(link_with: plugin, variables: {'full_path': plugin.full_path()})
+    meson.override_dependency(plugin.name(), dep)
+    gst_plugins += [dep]
+  endforeach
+endif

--- a/sys/v4l2video/meson.build
+++ b/sys/v4l2video/meson.build
@@ -89,7 +89,7 @@ if v4l2_mxc_source_sink_enabled or v4l2_isi_enabled or v4l2_amphion_enabled
 endif
 
 if source != []
-	library(
+	gstimxv4l2video = library(
 		'gstimxv4l2video',
 		source,
 		install : true,
@@ -97,4 +97,5 @@ if source != []
 		include_directories: [configinc, libsinc],
 		dependencies: dependencies
 	)
+	plugins += [gstimxv4l2video]
 endif


### PR DESCRIPTION
Provides a default package name and export list of plugins.
This allows easy testing with a gstreamer devenv build.
