### PR TITLE
Prevent having empty audio plugin if no codec

### DIFF
--- a/ext/audio/meson.build
+++ b/ext/audio/meson.build
@@ -30,7 +30,7 @@ else
 endif
 
 
-source = ['plugin.c']
+source = []
 if libfslaudiocodec_dep.found()
 	source += ['gstimxuniaudiocodec.c', 'gstimxuniaudiodecoder.c']
 endif
@@ -39,6 +39,8 @@ if mp3encoder_dep.found()
 endif
 
 if source != []
+	source += ['plugin.c']
+
 	gstimxaudio = library(
 		'gstimxaudio',
 		source,


### PR DESCRIPTION
From my understanding is that gst-inspect-1.0 imxaudio will be shown but it won't do anything.